### PR TITLE
Remove basePath and assetPrefix from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,7 @@
 import type { NextConfig } from "next";
 
-const repo = "portfolio";
-const assetPrefix = `/${repo}/`;
-const basePath = `/${repo}`;
-
 const nextConfig: NextConfig = {
   output: "export",
-  assetPrefix: assetPrefix,
-  basePath: basePath,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
These settings are intended for deployments to a subdirectory (like GitHub Pages) and cause asset paths to be incorrect when deploying to a root domain on Vercel.

Removing them ensures that CSS, images, and other assets are loaded correctly from the root of the domain, fixing the broken styles on the Vercel deployment.